### PR TITLE
Fixes to event bridge rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3t-transform/test-n-vac",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "main": "src/test-helper-client.js",
   "repository": "https://github.com/3TTransform/test-n-vac.git",
   "author": "3t Transform",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@3t-transform/test-n-vac",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "main": "src/test-helper-client.js",
   "repository": "https://bitbucket.org/aisneutron/test-n-vac.git",
   "author": "3t Transform",

--- a/src/test-helper-client.js
+++ b/src/test-helper-client.js
@@ -168,11 +168,11 @@ const TestNVacClient = ({ serviceName, serviceSource, busName, region, detailTyp
         QueueUrl: queueUrl
       };
 
-      console.info(`\n > Purging testing queue: ${queueUrl}`);
+      console.info("\n > Purging testing queue");
       await sqs.send(new PurgeQueueCommand(params));
       // Wait after command issued before sending new events
       await new Promise(resolve => setTimeout(resolve, 3000));
-      console.info(`\tSQS queue purged!`);
+      console.info("\tSQS queue purged!");
 
     } catch (err) {
       console.error(`Error while purging testing queue: ${err.message}`, err);

--- a/src/test-helper-client.js
+++ b/src/test-helper-client.js
@@ -1,4 +1,4 @@
-const { SQSClient, CreateQueueCommand, DeleteQueueCommand, ReceiveMessageCommand } = require("@aws-sdk/client-sqs");
+const { SQSClient, CreateQueueCommand, DeleteQueueCommand, ReceiveMessageCommand, PurgeQueueCommand } = require("@aws-sdk/client-sqs");
 const { EventBridgeClient, PutRuleCommand, PutTargetsCommand, RemoveTargetsCommand, DeleteRuleCommand, PutEventsCommand } = require("@aws-sdk/client-eventbridge");
 const { STSClient, GetCallerIdentityCommand } = require("@aws-sdk/client-sts");
 const { fromEnv } = require("@aws-sdk/credential-providers");
@@ -42,22 +42,150 @@ const TestNVacClient = ({ serviceName, serviceSource, busName, region, waitForIn
     'test-n-vac': serviceSource
   };
 
-  return {
+  /**
+   * A function that gets messages from sqs and returns them as an array.
+   * @async
+   */
+  const getMessagesFromSQS = async (waitTimeSeconds = 20, attempts = 4) => {
+
+    const checkSQSQueue = async (waitTimeSeconds) => {
+      /**
+       * @type {ReceiveMessageCommandInput}
+       */
+      const params = {
+        QueueUrl: sqsQueueUrl,
+        WaitTimeSeconds: waitTimeSeconds
+      };
+
+      return (await sqs.send(new ReceiveMessageCommand(params))).Messages;
+    };
+
+    let outputEvents = await checkSQSQueue(waitTimeSeconds);
+    for (let i = 1; i < attempts + 1; i++) {
+      if (!outputEvents || outputEvents.length === 0) {
+        const tryAgainMsg = (i < attempts) ? `Trying again in ${waitTimeSeconds} seconds... Attempt: ${i}` : '';
+        console.info(`\tNo events found in SQS queue. ${tryAgainMsg}`);
+        outputEvents = await checkSQSQueue(waitTimeSeconds);
+      }
+      else {
+        break;
+      }
+    }
+
+    if (!outputEvents || outputEvents.length === 0) {
+      throw new Error(`No events found in SQS queue after ${attempts} attempt(s)`);
+    }
+
+    return outputEvents.map(event => JSON.parse(event.Body));
+  };
+
+  /**
+   * Fire an event to the eventBridge
+   *
+   * @async
+   * @param {string} event The entry to fire as the event, no need to include the event bus name as we generate it at the top of this file
+   * @param {string} detailType The detail type of the event
+  */
+  const fireEvent = async (event, detailType) => {
+    try {
+
+      /**
+       * @type {PutEventsCommand}
+       */
+      const params = {
+        Entries: [
+          {
+            Detail: JSON.stringify(event),
+            DetailType: detailType,
+            EventBusName: busName,
+            Source: serviceSource
+          }
+        ]
+      };
+
+      return eventBridge.send(new PutEventsCommand(params));
+
+    } catch (err) {
+      console.error(`Error in fireEvent while firing event: ${err.message}`, err);
+      // fail the test run if event cannot be raised
+      throw err;
+    };
+  };
+
+  /**
+   * Waits for Event Bridge Rule to be ready
+   *
+   * @async
+   * @param {number} timeout The maximum time to wait before returning rule not available
+  */
+  const waitForRule = async (timeout = 60) => {
     /**
-     * Creates the aws architecture used for testing events
+     * Checks if Event Bridge Rule is ready to use, by firing events to it and looking for them in the SQS queue.
+     *
      * @async
-     */
-    createTestArchitecture: async () => {
+    */
+    const checkRuleReady = async () => {
+      try {
+        await fireEvent({}, `Test Event`);
+        // only retry once as we keep firing events
+        const numberOfMessages = (await getMessagesFromSQS(2, 1)).length || 0;
+        return numberOfMessages > 0;
+      } catch (err) {
+        // Rule is not ready, try again later
+        return false;
+      }
+    };
+
+    console.info('\n > Checking EB rule');
+    const startTime = Date.now();
+    while ((Date.now() - startTime) / 1000 < timeout) {
+      if (await checkRuleReady()) {
+        console.info('\tEB Rule ready!');
+        return;
+      }
+    }
+
+    // fail the test run if the SQS queue is not ready
+    throw new Error(`Rule ${ruleName} did not become ready within ${timeout} seconds`);
+  };
+
+  /**
+   * Purges an SQS queue
+   * @async
+   * @param {string} queueUrl The URL of the AWS SQS queue
+   */
+  const purgeQueue = async (queueUrl) => {
+    try {
+      /**
+       * @type {PurgeQueueCommandInput}
+       */
+      const params = {
+        QueueUrl: queueUrl
+      };
+
+      console.info(`\n > Purging testing queue: ${queueUrl}`);
+      await sqs.send(new PurgeQueueCommand(params));
+      console.info(`\tSQS queue purged!`);
+
+    } catch (err) {
+      console.error(`Error while purging testing queue: ${err.message}`, err);
+      // fail the test run, as there are issues with the SQS queue
+      throw err;
+    }
+  };
+
+  /**
+   * Creates the aws architecture used for testing events
+   * @async
+   */
+  const createTestArchitecture = async () => {
+    try {
+      console.info("\n > Creating AWS Resources");
       /**
        * The Amazon Web Services ARN associated with the calling entity.
        * @const {string}
        */
-      const accountId = await sts.send(new GetCallerIdentityCommand())
-        .then(data => data.Account)
-        .catch(err => {
-          console.error("Error in createTestArchitecture while getting accountId: ", err);
-          throw err;
-        });
+      const accountId = (await sts.send(new GetCallerIdentityCommand())).Account;
 
       // Create a temporary AWS SQS queue
       /**
@@ -84,13 +212,9 @@ const TestNVacClient = ({ serviceName, serviceSource, busName, region, waitForIn
         tags
       };
 
-      console.info("Creating testing queue: " + sqsQueueName);
-      sqsQueueUrl = await sqs.send(new CreateQueueCommand(params))
-        .then(data => data.QueueUrl)
-        .catch(err => {
-          console.error("Error in createTestArchitecture while creating testing queue: ", err);
-        });
-        
+      console.info(`\tCreating testing queue: ${sqsQueueName}`);
+      sqsQueueUrl = (await sqs.send(new CreateQueueCommand(params))).QueueUrl;
+
       // Create an eventBridge rule
       /**
        * @type {PutRuleCommandInput}
@@ -98,19 +222,16 @@ const TestNVacClient = ({ serviceName, serviceSource, busName, region, waitForIn
       const eventBridgeRule = {
         Name: eventBridgeRuleName,
         EventPattern: `{
-          "source": [
-            "${serviceSource}"
-          ]
-        }`,
+            "source": [
+              "${serviceSource}"
+            ]
+          }`,
         EventBusName: busName,
         tags
       };
 
-      console.info("Creating testing rule: " + eventBridgeRuleName);
-      await eventBridge.send(new PutRuleCommand(eventBridgeRule))
-        .catch(err => {
-          console.error("Error in createTestArchitecture while creating testing rule: ", err);
-        });
+      console.info(`\tCreating testing rule: ${eventBridgeRuleName}`);
+      await eventBridge.send(new PutRuleCommand(eventBridgeRule));
 
       // Create an eventBridge target
       /**
@@ -127,107 +248,60 @@ const TestNVacClient = ({ serviceName, serviceSource, busName, region, waitForIn
         ]
       };
 
-      console.info("Creating testing target: " + eventBridgeTargetId);
-      await eventBridge.send(new PutTargetsCommand(eventBridgeTarget))
-        .catch(err => {
-          console.error("Error in createTestArchitecture while creating testing target: ", err);
-        });
+      console.info(`\tCreating testing target: ${eventBridgeTargetId}`);
+      await eventBridge.send(new PutTargetsCommand(eventBridgeTarget));
 
-      await new Promise(resolve => setTimeout(resolve, waitForInfrastructure));
-    },
+      // EB rules can take aorund 60 seconds to be ready to use
+      await waitForRule();
+      
+      await purgeQueue(sqsQueueUrl);
+      // await new Promise(resolve => setTimeout(resolve, 5000));
+      console.info("\n > Running tests");
+    } catch (err) {
+      console.error(`Error in createTestArchitecture: ${err.message}`, err);
+      throw err;
+    }
+  };
 
-    /**
-     * Tears down the aws architecture used for testing events
-     * @async
-     */
-    destroyTestArchitecture: async () => {
+  /**
+   * Tears down the aws architecture used for testing events
+   * @async
+   */
+  const destroyTestArchitecture = async () => {
+    try {
+      console.info("\n > Destroying AWS Resources");
       // Delete the EventBridge target
-      console.info("Destroying testing target: " + eventBridgeTargetId);
-      await eventBridge.send(new RemoveTargetsCommand({ Ids: [eventBridgeTargetId], Rule: eventBridgeRuleName, EventBusName: busName }))
-        .catch(err => {
-          console.error("Error in destroyTestArchitecture while destroying testing target: ", err);
-        });
+      console.info(`\tDestroying testing target: ${eventBridgeTargetId}`);
+      await eventBridge.send(new RemoveTargetsCommand({ Ids: [eventBridgeTargetId], Rule: eventBridgeRuleName, EventBusName: busName }));
 
       // Delete the EventBridge rule
-      console.info("Destroying testing rule: " + eventBridgeRuleName);
-      await eventBridge.send(new DeleteRuleCommand({ EventBusName: busName, Name: eventBridgeRuleName }))
-        .catch(err => {
-          console.error("Error in destroyTestArchitecture while destroying testing rule: ", err);
-        });
+      console.info(`\tDestroying testing rule: ${eventBridgeRuleName}`);
+      await eventBridge.send(new DeleteRuleCommand({ EventBusName: busName, Name: eventBridgeRuleName }));
 
       // Remove the SQS queue
-      console.info("Destroying testing queue: " + sqsQueueName);
+      console.info(`\tDestroying testing queue: ${sqsQueueName}`);
       await sqs.send(new DeleteQueueCommand({
         QueueUrl: sqsQueueUrl
-      }))
-        .catch(err => {
-          console.error("Error in destroyTestArchitecture while destroying testing queue: ", err);
-        });
-    },
+      }));
 
-    /**
-     * A function that gets messages from sqs and returns them as an array.
-     * @async
-     */
-    getMessagesFromSQS: async () => {
-
-      const checkSQSQueue = async () => {
-        /**
-         * @type {ReceiveMessageCommandInput}
-         */
-        const params = {
-          QueueUrl: sqsQueueUrl,
-          WaitTimeSeconds: 20
-        };
-
-        return sqs.send(new ReceiveMessageCommand(params))
-          .then(data => data.Messages)
-          .catch(err => {
-            console.error("Error in getMessagesFromSQS while checking SQS queue: ", err);
-          });
-      };
-
-      let outputEvents = await checkSQSQueue();
-
-      for (let i = 1; i < 5; i++) {
-        if (!outputEvents || outputEvents.length === 0) {
-          console.log('No events found in SQS queue. Trying again in 20 seconds... Attempt: ' + i);
-          outputEvents = await checkSQSQueue();
-        }
-        else {
-          break;
-        }
-      }
-
-      if (!outputEvents || outputEvents.length === 0) {
-        throw new Error('No events found in SQS queue');
-      }
-
-      return outputEvents.map(event => JSON.parse(event.Body));
-    },
-    /**
-     * Fire an event to the eventBridge
-     *
-     * @async
-     * @param {string} event The entry to fire as the event, no need to include the event bus name as we generate it at the top of this file
-     * @param {string} detailType The detail type of the event
-    */
-    fireEvent: async (event, detailType) => {
-      const params = {
-        Entries: [
-          {
-            Detail: JSON.stringify(event),
-            DetailType: detailType,
-            EventBusName: busName,
-            Source: serviceSource
-          }
-        ]
-      };
-      return eventBridge.send(new PutEventsCommand(params))
-        .catch(err => {
-          console.error("Error in fireEvent while firing event: ", err);
-        });
+    } catch (err) {
+      console.error(`Error in destroyTestArchitecture: ${err.message}`, err);
+      // Notify user that they must destroy these AWS resources manually
+      console.info("!!!IMPORTANT!!!: please ensure the following AWS resources have been removed:\n"
+        + `Event Bridge Rule Target: ${eventBridgeTargetId}\n`
+        + `Event Bridge Rule: ${eventBridgeRuleName}\n`
+        + `SQS queue: ${sqsQueueName}`);
+      // fail the test run (otherwise people might forget to remove the AWS resources)
+      throw err;
     }
+  };
+
+
+  return {
+    createTestArchitecture,
+    destroyTestArchitecture,
+    getMessagesFromSQS,
+    fireEvent
   };
 };
 


### PR DESCRIPTION
This PR fixes:

- Removes waiting time for infrastructure to be ready
- Adds loop to check if EB rule is ready
- Fails the tests when an exception is raised (and moved to async/await instead of promise chaining)
- Purges the SQS queue after EB rule is ready (this might not be necessary, but seems to help)
- Passes a list of detail types to the client so EB rule only listens to those event details (this avoids testing those events raised by other services called by the tested service)


The test client now becomes:

```
const helperClient = TestNVacClient({
    serviceName: "vantage-test-service",
    serviceSource: `transform.test.integration.${Math.random().toString(16).substring(2, 10)}`,
    busName: eventBridgeArn.substring(eventBridgeArn.lastIndexOf("/") + 1, eventBridgeArn.length),
    region: awsRegion,
    detailTypes: [
        "Put Vantage ID",
        "Update Integration",
        "Put Attestation",
        "Put Pusher Notification"
    ]
});
```

The output looks like:

<img width="917" alt="Screenshot 2023-11-07 at 10 29 13" src="https://github.com/3TTransform/test-n-vac/assets/125556835/752b9515-78d5-42c9-8ad7-f5823cff9b51">



